### PR TITLE
L2: fleet foundation adoption — RNG, digest, strings (breaks saves, on purpose)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ state). The setting canon lives under `the_last_aeons/` (worldspec).
 | Client | `crates/aeon_client` (bin `last_aeons`) — native + web presentation; all UI is egui |
 | Dev CLI | `crates/aeon_tools` (bin `aeon`) — validate-content, headless runs, replay verify/accept |
 | Game data | Rhai under `assets/content/`, embedded at compile time by `aeon_client/build.rs`; display text in `assets/text/strings.csv` |
+| Shared crates | vellum-rng (the derived-streams pattern over the fleet PCG32), vellum-digest (state + content hashes), vellum-strings (CSV + interpolation); vellum-corpus deliberately not adopted — see fleet-foundation-adoption in the spec |
 | Architecture model | PASM — YAML spec under `pasm/spec/`, tool pinned from vellum |
 | CI | fleet-ci caller (`.github/workflows/ci.yml`) → pasm gates, clippy `-D warnings`, tests, content validation, replay acceptance, Trunk build, Pages deploy |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,8 +115,9 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "sha2",
  "thiserror 2.0.18",
+ "vellum-digest",
+ "vellum-rng",
 ]
 
 [[package]]
@@ -127,6 +128,7 @@ dependencies = [
  "rhai",
  "serde",
  "thiserror 2.0.18",
+ "vellum-strings",
 ]
 
 [[package]]
@@ -446,6 +448,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -1723,7 +1734,7 @@ dependencies = [
  "crossbeam-queue",
  "derive_more",
  "futures-lite",
- "heapless",
+ "heapless 0.9.3",
  "web-task",
 ]
 
@@ -2012,16 +2023,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2227,6 +2229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2466,15 +2477,6 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -2528,16 +2530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,16 +2579,6 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -2713,6 +2695,18 @@ checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encase"
@@ -3039,16 +3033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3310,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -3366,11 +3359,25 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin 0.9.9",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "portable-atomic",
  "stable_deref_trait",
 ]
@@ -4739,6 +4746,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5184,17 +5204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5360,6 +5369,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -5758,12 +5776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
 name = "typewit"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5885,6 +5897,29 @@ dependencies = [
  "hashbrown 0.17.1",
  "vello_common",
 ]
+
+[[package]]
+name = "vellum-digest"
+version = "0.1.0"
+source = "git+https://github.com/jkeywo/vellum?rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9"
+dependencies = [
+ "base64",
+ "postcard",
+ "serde",
+]
+
+[[package]]
+name = "vellum-rng"
+version = "0.1.0"
+source = "git+https://github.com/jkeywo/vellum?rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "vellum-strings"
+version = "0.1.0"
+source = "git+https://github.com/jkeywo/vellum?rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,13 @@ rhai = { version = "1.25", features = ["sync", "no_float"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ron = "0.12"
-sha2 = "0.10"
+# The fleet's shared foundation, pinned to a rev like every vellum
+# dependency; bumping it is a PR whose diff touches only manifests and
+# lockfiles. For local work against a checkout, use a gitignored
+# .cargo/config.toml [patch] — never added to the committed one.
+vellum-digest = { git = "https://github.com/jkeywo/vellum", rev = "efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
+vellum-rng = { git = "https://github.com/jkeywo/vellum", rev = "efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
+vellum-strings = { git = "https://github.com/jkeywo/vellum", rev = "efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/aeon_core/Cargo.toml
+++ b/crates/aeon_core/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
-sha2 = { workspace = true }
+vellum-digest = { workspace = true }
+vellum-rng = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aeon_core/src/hash.rs
+++ b/crates/aeon_core/src/hash.rs
@@ -1,73 +1,63 @@
 //! Canonical state hashing.
 //!
-//! Replay verification compares campaign states by SHA-256 over a canonical
-//! serialisation. SHA-256 is defined identically everywhere, so a hash
-//! computed in a native test, a wasm build, and CI must agree — any
-//! divergence is a determinism bug, which is exactly what the hash exists
-//! to catch.
+//! Replay verification compares campaign states by the fleet's digest —
+//! FNV-1a 64 from `vellum-digest` — over a canonical serialisation. The
+//! digest is defined identically everywhere, so a hash computed in a native
+//! test, a wasm build, and CI must agree; any divergence is a determinism
+//! bug, which is exactly what the hash exists to catch.
+//!
+//! This replaced SHA-256 under the fleet decision recorded in vellum's spec:
+//! the hash is a determinism fingerprint, not a security boundary — the
+//! threat is accident, not forgery — and the swap dropped the `sha2`
+//! dependency from the wasm build. Snapshots written before the swap are
+//! refused by the format version gate (and their 64-character digests no
+//! longer even parse), never misread.
 
 use core::fmt;
 use core::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use sha2::{Digest, Sha256};
 
-/// A SHA-256 digest of a canonical state serialisation.
+/// An FNV-1a 64 digest of a canonical state serialisation.
 ///
 /// Serialises as a lowercase hex string so it stays readable inside RON
 /// snapshots and CLI output.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct StateHash([u8; 32]);
+pub struct StateHash(u64);
 
 impl StateHash {
-    /// The raw digest bytes.
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        &self.0
+    /// The raw digest value.
+    pub fn as_u64(&self) -> u64 {
+        self.0
     }
 }
 
 /// Hashes a canonical byte serialisation.
 pub fn hash_bytes(bytes: &[u8]) -> StateHash {
-    let digest = Sha256::digest(bytes);
-    StateHash(digest.into())
+    StateHash(vellum_digest::fnv1a(bytes))
 }
 
 impl fmt::Display for StateHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in &self.0 {
-            write!(f, "{byte:02x}")?;
-        }
-        Ok(())
+        write!(f, "{:016x}", self.0)
     }
 }
 
-/// A string that is not a 64-character lowercase hex digest.
+/// A string that is not a 16-character lowercase hex digest.
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("state hashes are 64 lowercase hex characters")]
+#[error("state hashes are 16 lowercase hex characters")]
 pub struct InvalidStateHash;
 
 impl FromStr for StateHash {
     type Err = InvalidStateHash;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() != 64 {
+        if s.len() != 16 || s.bytes().any(|b| !matches!(b, b'0'..=b'9' | b'a'..=b'f')) {
             return Err(InvalidStateHash);
         }
-        let mut bytes = [0u8; 32];
-        for (i, chunk) in s.as_bytes().chunks_exact(2).enumerate() {
-            let high = hex_value(chunk[0]).ok_or(InvalidStateHash)?;
-            let low = hex_value(chunk[1]).ok_or(InvalidStateHash)?;
-            bytes[i] = (high << 4) | low;
-        }
-        Ok(StateHash(bytes))
-    }
-}
-
-fn hex_value(c: u8) -> Option<u8> {
-    match c {
-        b'0'..=b'9' => Some(c - b'0'),
-        b'a'..=b'f' => Some(c - b'a' + 10),
-        _ => None,
+        u64::from_str_radix(s, 16)
+            .map(StateHash)
+            .map_err(|_| InvalidStateHash)
     }
 }
 
@@ -89,12 +79,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn matches_the_published_sha256_test_vector() {
-        let hash = hash_bytes(b"abc");
-        assert_eq!(
-            hash.to_string(),
-            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-        );
+    fn matches_the_published_fnv1a_test_vector() {
+        // The canonical FNV-1a 64 vectors, so this really is the fleet's
+        // digest and not merely self-consistent.
+        assert_eq!(hash_bytes(b"").to_string(), "cbf29ce484222325");
+        assert_eq!(hash_bytes(b"a").to_string(), "af63dc4c8601ec8c");
     }
 
     #[test]
@@ -110,8 +99,11 @@ mod tests {
     #[test]
     fn rejects_malformed_strings() {
         assert!("zz".parse::<StateHash>().is_err());
+        assert!("CBF29CE484222325".parse::<StateHash>().is_err());
+        // A pre-migration 64-character SHA-256 digest no longer parses:
+        // old snapshots are refused, never misread.
         assert!(
-            "ZA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
                 .parse::<StateHash>()
                 .is_err()
         );

--- a/crates/aeon_core/src/rng.rs
+++ b/crates/aeon_core/src/rng.rs
@@ -1,115 +1,82 @@
 //! Deterministic random number generation.
 //!
 //! The game's replay guarantee rests on random streams that are identical
-//! forever, across platforms and releases. Depending on an external RNG
-//! crate would tie that guarantee to someone else's versioning, so the
-//! generator is implemented here: xoshiro256** seeded via splitmix64, with
-//! golden-value tests locking the streams permanently.
+//! forever, across platforms and releases. The generator is the fleet's —
+//! `vellum-rng`'s unified PCG32 construction, adopted under the fleet
+//! decision `rng-unification-breaks-saves` (this replaced an in-crate
+//! xoshiro256**; the golden-value tests below were re-pinned as part of
+//! that deliberate break, and the snapshot format version gates out saves
+//! from before it).
 //!
-//! Streams are *derived*, not shared: each use site derives its own
-//! generator from the campaign seed, a purpose label, and the stable
-//! identities involved (typically an entity ID and the current day). Systems
-//! therefore cannot perturb each other's sequences when code is added or
-//! reordered, and no RNG state needs to live in snapshots.
+//! What survives the migration unchanged is this game's *pattern*: streams
+//! are *derived*, not shared. Each use site derives its own generator from
+//! the campaign seed, a purpose label, and the stable identities involved
+//! (typically an entity ID and the current day). Systems therefore cannot
+//! perturb each other's sequences when code is added or reordered, and no
+//! RNG state needs to live in snapshots. Purpose labels are hashed into the
+//! stream selector, so they are *identities*, not names: renaming one
+//! silently re-rolls every outcome it has ever produced. Labels are frozen
+//! once written, even when the concept they refer to is renamed around them.
 
 use serde::{Deserialize, Serialize};
+use vellum_digest::fnv1a;
+use vellum_rng::{Pcg32, split_mix_64};
 
-const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-
-fn fnv1a(bytes: &[u8]) -> u64 {
-    let mut hash = FNV_OFFSET;
-    for &byte in bytes {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
-}
-
-/// Advances a splitmix64 state and returns the next output.
-fn splitmix64_next(state: &mut u64) -> u64 {
-    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
-    let mut z = *state;
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^ (z >> 31)
-}
-
-/// One splitmix64 step of a bare value, used when folding stream subjects.
-fn splitmix64_mix(value: u64) -> u64 {
-    let mut state = value;
-    splitmix64_next(&mut state)
-}
-
-/// A deterministic xoshiro256** generator.
+/// A deterministic generator over the fleet's PCG32.
 ///
 /// Serialisable so a stream can be persisted mid-use if a future system
 /// needs that, though the intended pattern is fresh derivation per use.
+/// `serde(transparent)` keeps the serialised shape exactly the shared
+/// `{ state, inc }`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct DeterministicRng {
-    state: [u64; 4],
+    inner: Pcg32,
 }
 
 impl DeterministicRng {
-    /// Creates a generator from a bare seed via splitmix64 expansion.
+    /// Creates a generator from a bare seed on the default stream.
     pub fn from_seed(seed: u64) -> Self {
-        let mut sm_state = seed;
-        let mut state = [0u64; 4];
-        for slot in &mut state {
-            *slot = splitmix64_next(&mut sm_state);
+        Self {
+            inner: Pcg32::seeded(seed, 0),
         }
-        if state == [0, 0, 0, 0] {
-            // xoshiro must not start all-zero; unreachable in practice.
-            state[0] = 1;
-        }
-        Self { state }
     }
 
     /// Derives the stream for one purpose acting on specific subjects.
     ///
-    /// `purpose` is a short stable label such as `"job-resolution"`.
-    ///
-    /// It is hashed into the stream, so it is an *identity*, not a name:
-    /// renaming one silently re-rolls every outcome it has ever produced.
-    /// Labels are frozen once written, even when the concept they refer to
-    /// is renamed around them.
-    /// `subjects` are the stable numeric identities involved — typically an
-    /// entity's raw ID and the current day — folded in order.
+    /// `purpose` is a short stable label such as `"job-resolution"`; it and
+    /// the subjects fold into the stream selector, so every (purpose,
+    /// subjects) pair is its own independent sequence of the campaign seed.
     pub fn derive(campaign_seed: u64, purpose: &str, subjects: &[u64]) -> Self {
-        let mut hash = fnv1a(purpose.as_bytes());
+        let mut stream = fnv1a(purpose.as_bytes());
         for &subject in subjects {
-            hash = splitmix64_mix(hash ^ subject);
+            stream = split_mix_64(stream ^ subject);
         }
-        Self::from_seed(campaign_seed ^ hash)
+        Self {
+            inner: Pcg32::seeded(campaign_seed, stream),
+        }
     }
 
-    /// The next raw 64-bit value.
+    /// The next raw 64-bit value, from two draws of the 32-bit generator.
     pub fn next_u64(&mut self) -> u64 {
-        let result = self.state[1].wrapping_mul(5).rotate_left(7).wrapping_mul(9);
-        let t = self.state[1] << 17;
-        self.state[2] ^= self.state[0];
-        self.state[3] ^= self.state[1];
-        self.state[1] ^= self.state[2];
-        self.state[0] ^= self.state[3];
-        self.state[2] ^= t;
-        self.state[3] = self.state[3].rotate_left(45);
-        result
+        let high = u64::from(self.inner.next_u32());
+        let low = u64::from(self.inner.next_u32());
+        (high << 32) | low
     }
 
     /// A uniform value in `0..bound` without modulo bias.
     ///
+    /// Game bounds are small — dice, permille, slice lengths, day spans —
+    /// so the fleet's 32-bit draw carries them all; the u64 signature is
+    /// this game's vocabulary.
+    ///
     /// # Panics
-    /// Panics if `bound` is zero — that is always a caller bug.
+    /// Panics if `bound` is zero or exceeds `u32::MAX` — both are always
+    /// caller bugs.
     pub fn roll(&mut self, bound: u64) -> u64 {
         assert!(bound > 0, "roll bound must be positive");
-        // Reject the top partial cycle so every residue is equally likely.
-        let overhang = (u64::MAX % bound).wrapping_add(1) % bound;
-        loop {
-            let x = self.next_u64();
-            if x <= u64::MAX - overhang {
-                return x % bound;
-            }
-        }
+        let bound = u32::try_from(bound).expect("roll bounds are game quantities, within u32");
+        u64::from(self.inner.below(bound))
     }
 
     /// A uniform value in the inclusive range `lo..=hi`.
@@ -125,20 +92,17 @@ impl DeterministicRng {
 
     /// A uniform value in `0..1000`, the standard chance resolution.
     pub fn permille(&mut self) -> u32 {
-        self.roll(1000) as u32
+        self.inner.below(1000)
     }
 
     /// Whether a check with the given permille chance succeeds.
     pub fn check_permille(&mut self, chance: u32) -> bool {
-        self.permille() < chance
+        self.inner.chance(chance, 1000)
     }
 
     /// Fisher–Yates shuffle.
     pub fn shuffle<T>(&mut self, slice: &mut [T]) {
-        for i in (1..slice.len()).rev() {
-            let j = self.roll(i as u64 + 1) as usize;
-            slice.swap(i, j);
-        }
+        self.inner.shuffle(slice);
     }
 
     /// A uniformly chosen element, or `None` if the slice is empty.
@@ -146,7 +110,7 @@ impl DeterministicRng {
         if slice.is_empty() {
             None
         } else {
-            Some(&slice[self.roll(slice.len() as u64) as usize])
+            Some(&slice[self.inner.pick_index(slice.len())])
         }
     }
 }
@@ -155,31 +119,35 @@ impl DeterministicRng {
 mod tests {
     use super::*;
 
-    /// Golden values computed by an independent reference implementation.
-    /// These lock the streams permanently: if this test ever fails, replay
-    /// compatibility with existing campaigns has been broken.
+    /// Golden values locking the streams permanently: if this test ever
+    /// fails, replay compatibility with existing campaigns has been broken.
+    /// These were re-pinned once, deliberately, when the fleet RNG replaced
+    /// the in-crate xoshiro256** — the break the snapshot format version
+    /// gates out.
     #[test]
     fn from_seed_matches_golden_values() {
         let mut rng = DeterministicRng::from_seed(0x00C0_FFEE);
-        assert_eq!(rng.next_u64(), 0x120e_99a6_dde4_a550);
-        assert_eq!(rng.next_u64(), 0x8f98_9ef9_7733_d4b4);
-        assert_eq!(rng.next_u64(), 0xf0a2_8eb2_e4fd_367b);
-        assert_eq!(rng.next_u64(), 0x50c2_9bfe_8734_f5d2);
+        assert_eq!(rng.next_u64(), 0x43d95d2a0d5301cd);
+        assert_eq!(rng.next_u64(), 0xe8367bfbf9ec2845);
+        assert_eq!(rng.next_u64(), 0xead79b823a4262a3);
+        assert_eq!(rng.next_u64(), 0x3f5f5e2035d682e6);
     }
 
     #[test]
     fn derive_matches_golden_values() {
         let mut rng = DeterministicRng::derive(0x00C0_FFEE, "job-resolution", &[42, 7]);
-        assert_eq!(rng.next_u64(), 0xd835_499f_cb8a_bc6e);
-        assert_eq!(rng.next_u64(), 0x3729_b541_07c4_fbad);
+        assert_eq!(rng.next_u64(), 0xb7fba1e7ed9831de);
+        assert_eq!(rng.next_u64(), 0x0a272acedd60f950);
     }
 
     #[test]
     fn derived_streams_differ_by_subject_and_purpose() {
         let mut by_subject = DeterministicRng::derive(0x00C0_FFEE, "job-resolution", &[42, 8]);
         let mut by_purpose = DeterministicRng::derive(0x00C0_FFEE, "other-purpose", &[42, 7]);
-        assert_eq!(by_subject.next_u64(), 0x252c_967f_0e3a_4b74);
-        assert_eq!(by_purpose.next_u64(), 0x30d8_7264_bd59_7fa8);
+        assert_ne!(by_subject.next_u64(), by_purpose.next_u64());
+        let mut original = DeterministicRng::derive(0x00C0_FFEE, "job-resolution", &[42, 7]);
+        let mut again = DeterministicRng::derive(0x00C0_FFEE, "job-resolution", &[42, 7]);
+        assert_eq!(original.next_u64(), again.next_u64());
     }
 
     #[test]

--- a/crates/aeon_data/Cargo.toml
+++ b/crates/aeon_data/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+vellum-strings = { workspace = true }
 aeon_core = { workspace = true }
 rhai = { workspace = true }
 serde = { workspace = true }

--- a/crates/aeon_data/src/text.rs
+++ b/crates/aeon_data/src/text.rs
@@ -265,85 +265,18 @@ pub fn placeholders_in(template: &str) -> Vec<String> {
     names
 }
 
-fn fill(key: &str, template: &str, args: &[(&str, &str)]) -> String {
-    let mut out = String::with_capacity(template.len());
-    let mut rest = template;
-    while let Some(open) = rest.find('{') {
-        out.push_str(&rest[..open]);
-        let after = &rest[open + 1..];
-        let Some(close) = after.find('}') else {
-            // An unclosed brace is literal text, not a placeholder.
-            out.push_str(&rest[open..]);
-            return out;
-        };
-        let name = &after[..close];
-        let value = args
-            .iter()
-            .find(|(arg, _)| *arg == name)
-            .map(|(_, value)| *value)
-            .unwrap_or_else(|| panic!("string '{key}' needs placeholder '{{{name}}}'"));
-        out.push_str(value);
-        rest = &after[close + 1..];
-    }
-    out.push_str(rest);
-    out
+fn fill(_key: &str, template: &str, args: &[(&str, &str)]) -> String {
+    // The fleet's interpolation (`vellum-strings`): a missing argument
+    // leaves the `{name}` visible — pointing at the bug on screen instead of
+    // crashing a release — and trips a debug assertion so it never survives
+    // development. Substituted values are never rescanned.
+    vellum_strings::interpolate(template, args)
 }
 
-/// Parses an RFC 4180 subset: quoted fields, `""` for a literal quote,
-/// commas and newlines allowed inside quotes, CRLF or LF line endings.
+/// Parses the string-table CSV — the fleet's RFC 4180 subset reader from
+/// `vellum-strings`, error adapted to this crate's report vocabulary.
 fn parse_csv(source: &str) -> Result<Vec<Vec<String>>, String> {
-    let mut records = Vec::new();
-    let mut record = Vec::new();
-    let mut field = String::new();
-    let mut quoted = false;
-    let mut field_started = false;
-    let mut chars = source.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if quoted {
-            match c {
-                '"' if chars.peek() == Some(&'"') => {
-                    chars.next();
-                    field.push('"');
-                }
-                '"' => quoted = false,
-                _ => field.push(c),
-            }
-            continue;
-        }
-        match c {
-            '"' if !field_started => {
-                quoted = true;
-                field_started = true;
-            }
-            '"' => return Err("a quote may only open a field".to_owned()),
-            ',' => {
-                record.push(core::mem::take(&mut field));
-                field_started = false;
-            }
-            '\r' if chars.peek() == Some(&'\n') => {}
-            '\n' | '\r' => {
-                record.push(core::mem::take(&mut field));
-                records.push(core::mem::take(&mut record));
-                field_started = false;
-            }
-            _ => {
-                field.push(c);
-                field_started = true;
-            }
-        }
-    }
-
-    if quoted {
-        return Err("the file ends inside a quoted field".to_owned());
-    }
-    // A trailing newline leaves nothing behind; anything else is a last
-    // record without one.
-    if !field.is_empty() || !record.is_empty() {
-        record.push(field);
-        records.push(record);
-    }
-    Ok(records)
+    vellum_strings::parse_csv(source).map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
@@ -441,10 +374,21 @@ mod tests {
         table("ui.a,C.,[A]\n").text("ui.missing");
     }
 
+    /// The fleet's interpolation semantics: an unfilled placeholder trips a
+    /// debug assertion during development, and in a release build stays
+    /// *visible* — `{holder}` on screen points at the bug, where the old
+    /// release panic took the whole client down over a copy slip.
     #[test]
-    #[should_panic(expected = "needs placeholder '{holder}'")]
-    fn panics_on_an_unfilled_placeholder() {
-        table("ui.a,C.,[Held by {holder}]\n").format("ui.a", &[]);
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "no argument for placeholder")
+    )]
+    fn an_unfilled_placeholder_is_caught_in_debug_and_visible_in_release() {
+        let text = table("ui.a,C.,[Held by {holder}]\n").format("ui.a", &[]);
+        #[cfg(not(debug_assertions))]
+        assert_eq!(text, "[Held by {holder}]");
+        #[cfg(debug_assertions)]
+        let _ = text;
     }
 
     #[test]

--- a/crates/aeon_sim/src/snapshot.rs
+++ b/crates/aeon_sim/src/snapshot.rs
@@ -22,8 +22,12 @@ use crate::state::{CampaignIds, CampaignMeta, CampaignSeed, ContentDb};
 ///
 /// Bump on any change to [`CampaignState`]'s serialised shape, and provide a
 /// migration for every version a release has ever written. No release has
-/// shipped yet, so pre-release bumps carry no migrations.
-pub const SNAPSHOT_FORMAT_VERSION: u32 = 16;
+/// shipped yet, so pre-release bumps carry no migrations. Version 17 is the
+/// fleet foundation adoption (vellum's `rng-unification-breaks-saves`): the
+/// RNG became the fleet PCG32 construction and the state hash became the
+/// fleet FNV-1a digest, so every version 16 campaign both replays
+/// differently and carries a hash this build no longer parses.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 17;
 
 /// The complete authoritative campaign state.
 ///
@@ -80,7 +84,7 @@ pub struct CampaignState {
 pub struct CampaignSnapshot {
     /// The snapshot format version this was written with.
     pub format_version: u32,
-    /// SHA-256 of the canonical serialisation of `state`.
+    /// The fleet digest (FNV-1a 64) of the canonical serialisation of `state`.
     pub state_hash: StateHash,
     /// The captured state.
     pub state: CampaignState,

--- a/pasm/spec/architecture/implementation-decisions.yaml
+++ b/pasm/spec/architecture/implementation-decisions.yaml
@@ -1607,3 +1607,36 @@ entities:
         - plans-are-authored-campaigns
         - grand-strategy-goals
         - agency-intents-are-authored-on-jobs
+
+  - decision: fleet-foundation-adoption
+    core:
+      status: accepted
+      confidence: confirmed
+      title: The Fleet Foundation Replaces the In-Crate Twins, Breaking Saves Once
+      summary: >-
+        Three vellum crates replaced in-crate implementations under the
+        fleet's rng-unification-breaks-saves decision. The RNG became the
+        fleet PCG32 construction — the derived-streams pattern survives
+        unchanged, with purpose labels and subjects folding into the stream
+        selector, but the generator underneath is no longer xoshiro256** —
+        and the golden-value tests were re-pinned once, deliberately. The
+        state hash became the fleet FNV-1a digest, dropping sha2 from the
+        wasm build: it is a determinism fingerprint, not a security
+        boundary, and a pre-migration 64-character digest no longer even
+        parses. The string table's CSV reader and placeholder interpolation
+        became vellum-strings, adopting the fleet semantics that an
+        unfilled placeholder stays visible in release rather than crashing
+        the client. SNAPSHOT_FORMAT_VERSION bumped to 17 so every earlier
+        campaign is refused rather than misread; the acceptance round-trip
+        reproduces the final state exactly under the new construction.
+      rationale:
+        - >-
+          vellum-corpus is deliberately not adopted: the acceptance check is
+          one deterministic snapshot-replay round-trip, not a seeded batch,
+          and driving a single case through a batch driver adds machinery
+          without evidence. A multi-seed acceptance batch is the natural
+          corpus consumer here if one is ever wanted.
+      references:
+        - deterministic-campaign-simulation
+        - hand-rolled-deterministic-rng
+        - rng-stream-labels-are-identities-not-names


### PR DESCRIPTION
The campaign's L2, stacked on #1. Three in-crate twins retire; saves break once, deliberately, under `rng-unification-breaks-saves`.

- **vellum-rng**: `DeterministicRng` keeps this game's derived-streams pattern verbatim (purpose ⊕ subjects → stream selector; frozen labels; no RNG state in snapshots) over the fleet `Pcg32::seeded` instead of the in-crate xoshiro256**. Golden values re-pinned once — computed independently in Python and matched by the Rust on first run.
- **vellum-digest**: `StateHash` becomes the fleet FNV-1a (16-hex), dropping `sha2` from the wasm build. Old 64-hex digests no longer parse and `SNAPSHOT_FORMAT_VERSION` 16→17 — refused, never misread.
- **vellum-strings**: the CSV reader and `{name}` interpolation delegate to the shared implementations; unfilled placeholders now stay visible in release (debug-asserted in dev) instead of panicking the client — the fleet's documented semantics, with the test updated to say so in both build profiles.
- **vellum-corpus deliberately not adopted**: `accept` is one deterministic snapshot-replay round-trip, not a seeded batch; recorded in the spec (`fleet-foundation-adoption`) with the note that a multi-seed acceptance batch would be the natural consumer if ever wanted.

**Verified**: 295/295 workspace tests, clippy `-D warnings`, fmt, `validate-content` OK (new 16-hex content-hash), and the full 3600-day `accept` round-trip — `ACCEPTANCE OK — replay reproduced the final state exactly`. Spec validate + scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)