### PR TITLE
L3: the script sandbox is the fleet's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   fleet:
-    uses: jkeywo/vellum/.github/workflows/fleet-ci.yml@41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471
+    uses: jkeywo/vellum/.github/workflows/fleet-ci.yml@61cf506e096854a3e05e1a19369deb0901d298d5
     with:
       # Bevy's audio/input need alsa/udev on ubuntu, and winit's Wayland
       # backend needs wayland/xkbcommon. The wasm job shares them for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   fleet:
-    uses: jkeywo/vellum/.github/workflows/fleet-ci.yml@efdb2d034e07baadd93e3cbf257ba8b3a3a571a9
+    uses: jkeywo/vellum/.github/workflows/fleet-ci.yml@41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471
     with:
       # Bevy's audio/input need alsa/udev on ubuntu, and winit's Wayland
       # backend needs wayland/xkbcommon. The wasm job shares them for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "vellum-digest"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
+source = "git+https://github.com/jkeywo/vellum?rev=61cf506e096854a3e05e1a19369deb0901d298d5#61cf506e096854a3e05e1a19369deb0901d298d5"
 dependencies = [
  "base64",
  "postcard",
@@ -5912,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "vellum-rng"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
+source = "git+https://github.com/jkeywo/vellum?rev=61cf506e096854a3e05e1a19369deb0901d298d5#61cf506e096854a3e05e1a19369deb0901d298d5"
 dependencies = [
  "serde",
 ]
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "vellum-script"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
+source = "git+https://github.com/jkeywo/vellum?rev=61cf506e096854a3e05e1a19369deb0901d298d5#61cf506e096854a3e05e1a19369deb0901d298d5"
 dependencies = [
  "rhai",
  "vellum-digest",
@@ -5929,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "vellum-strings"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
+source = "git+https://github.com/jkeywo/vellum?rev=61cf506e096854a3e05e1a19369deb0901d298d5#61cf506e096854a3e05e1a19369deb0901d298d5"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "rhai",
  "serde",
  "thiserror 2.0.18",
+ "vellum-script",
  "vellum-strings",
 ]
 
@@ -5901,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "vellum-digest"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9"
+source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
 dependencies = [
  "base64",
  "postcard",
@@ -5911,15 +5912,24 @@ dependencies = [
 [[package]]
 name = "vellum-rng"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9"
+source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
 dependencies = [
  "serde",
 ]
 
 [[package]]
+name = "vellum-script"
+version = "0.1.0"
+source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
+dependencies = [
+ "rhai",
+ "vellum-digest",
+]
+
+[[package]]
 name = "vellum-strings"
 version = "0.1.0"
-source = "git+https://github.com/jkeywo/vellum?rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9"
+source = "git+https://github.com/jkeywo/vellum?rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ ron = "0.12"
 # dependency; bumping it is a PR whose diff touches only manifests and
 # lockfiles. For local work against a checkout, use a gitignored
 # .cargo/config.toml [patch] — never added to the committed one.
-vellum-digest = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
-vellum-rng = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
-vellum-strings = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
-vellum-script = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
+vellum-digest = { git = "https://github.com/jkeywo/vellum", rev = "61cf506e096854a3e05e1a19369deb0901d298d5" }
+vellum-rng = { git = "https://github.com/jkeywo/vellum", rev = "61cf506e096854a3e05e1a19369deb0901d298d5" }
+vellum-strings = { git = "https://github.com/jkeywo/vellum", rev = "61cf506e096854a3e05e1a19369deb0901d298d5" }
+vellum-script = { git = "https://github.com/jkeywo/vellum", rev = "61cf506e096854a3e05e1a19369deb0901d298d5" }
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ ron = "0.12"
 # dependency; bumping it is a PR whose diff touches only manifests and
 # lockfiles. For local work against a checkout, use a gitignored
 # .cargo/config.toml [patch] — never added to the committed one.
-vellum-digest = { git = "https://github.com/jkeywo/vellum", rev = "efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
-vellum-rng = { git = "https://github.com/jkeywo/vellum", rev = "efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
-vellum-strings = { git = "https://github.com/jkeywo/vellum", rev = "efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
+vellum-digest = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
+vellum-rng = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
+vellum-strings = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
+vellum-script = { git = "https://github.com/jkeywo/vellum", rev = "41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/aeon_core/src/hash.rs
+++ b/crates/aeon_core/src/hash.rs
@@ -30,6 +30,12 @@ impl StateHash {
     pub fn as_u64(&self) -> u64 {
         self.0
     }
+
+    /// Wrap an already-computed fleet digest — for a hash produced by a
+    /// shared crate over its own framing (see `aeon_data`'s content hash).
+    pub const fn from_u64(digest: u64) -> Self {
+        Self(digest)
+    }
 }
 
 /// Hashes a canonical byte serialisation.

--- a/crates/aeon_data/Cargo.toml
+++ b/crates/aeon_data/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 vellum-strings = { workspace = true }
+vellum-script = { workspace = true }
 aeon_core = { workspace = true }
 rhai = { workspace = true }
 serde = { workspace = true }

--- a/crates/aeon_data/src/host/builders.rs
+++ b/crates/aeon_data/src/host/builders.rs
@@ -2492,7 +2492,7 @@ fn define_office(state: &mut BuilderState, map: Map) {
 
 /// Builds the loading engine with `define_*` functions bound to `state`.
 pub(super) fn loading_engine(state: Arc<Mutex<BuilderState>>) -> Engine {
-    let mut engine = super::sandboxed_engine();
+    let mut engine = vellum_script::sandbox();
 
     let print_state = state.clone();
     engine.on_print(move |text| {

--- a/crates/aeon_data/src/host/mod.rs
+++ b/crates/aeon_data/src/host/mod.rs
@@ -7,11 +7,14 @@
 //! - the *runtime* engine has no builder functions and never re-runs top
 //!   level; it only calls named functions retained in the compiled ASTs.
 //!
-//! The sandbox is deny-by-default for anything nondeterministic or
-//! stateful: no imports, no `eval`, no wall-clock, integer-only arithmetic
-//! (the crate builds Rhai with `no_float`), and hard operation, size, and
-//! recursion limits. Scripts read the context they are handed and return
-//! effect data; they cannot reach simulation state at all.
+//! The sandbox itself is the fleet's — `vellum-script`, extracted from this
+//! game — and stays deny-by-default for anything nondeterministic or
+//! stateful: no imports, no `eval`, no wall-clock, integer-only arithmetic,
+//! and hard operation, size, and recursion limits. What remains here is the
+//! *vocabulary*: which builder functions a loading engine registers, the
+//! shape of the context a call receives, and how a returned value becomes
+//! typed effects. Scripts read the context they are handed and return effect
+//! data; they cannot reach simulation state at all.
 //!
 //! The pieces live in submodules: [`builders`] turns authored maps into
 //! validated definitions, [`validate`] runs the cross-reference pass once
@@ -25,8 +28,7 @@ mod validate;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
-use aeon_core::hash::hash_bytes;
-use rhai::{AST, Dynamic, Engine, Map, Scope};
+use rhai::{AST, Dynamic, Engine, Map};
 
 use crate::effect::{EffectParseError, ScriptEffect, parse_effects};
 use crate::model::{ContentSet, ScriptFnRef};
@@ -46,53 +48,19 @@ pub struct ContentSource {
     pub source: String,
 }
 
-/// Builds a sandboxed engine from an allow-list of language packages.
-///
-/// Starting from a raw engine means capabilities are opt-in: no wall-clock
-/// (`timestamp` is simply absent), no I/O, no imports, no `eval`, and hard
-/// operation, size, and recursion limits. Only deterministic language
-/// features are registered.
-fn sandboxed_engine() -> Engine {
-    use rhai::packages::{
-        ArithmeticPackage, BasicArrayPackage, BasicFnPackage, BasicIteratorPackage,
-        BasicMapPackage, BasicMathPackage, BasicStringPackage, LanguageCorePackage, LogicPackage,
-        MoreStringPackage, Package,
-    };
-
-    let mut engine = Engine::new_raw();
-    engine.register_global_module(LanguageCorePackage::new().as_shared_module());
-    engine.register_global_module(ArithmeticPackage::new().as_shared_module());
-    engine.register_global_module(LogicPackage::new().as_shared_module());
-    engine.register_global_module(BasicStringPackage::new().as_shared_module());
-    engine.register_global_module(MoreStringPackage::new().as_shared_module());
-    engine.register_global_module(BasicIteratorPackage::new().as_shared_module());
-    engine.register_global_module(BasicArrayPackage::new().as_shared_module());
-    engine.register_global_module(BasicMapPackage::new().as_shared_module());
-    engine.register_global_module(BasicMathPackage::new().as_shared_module());
-    engine.register_global_module(BasicFnPackage::new().as_shared_module());
-
-    engine.set_module_resolver(rhai::module_resolvers::DummyModuleResolver::new());
-    engine.disable_symbol("eval");
-    engine.set_max_operations(5_000_000);
-    engine.set_max_call_levels(64);
-    engine.set_max_string_size(65_536);
-    engine.set_max_array_size(65_536);
-    engine.set_max_map_size(65_536);
-    engine.set_max_expr_depths(128, 64);
-    engine
-}
-
 /// Hashes the sorted source files; binds snapshots to exact content.
+///
+/// The framing (path, length, then bytes) is the fleet's, so a character
+/// moved across a file boundary still changes the hash.
 fn content_hash(sources: &[ContentSource]) -> aeon_core::hash::StateHash {
-    let mut buffer = Vec::new();
-    for source in sources {
-        buffer.extend_from_slice(source.path.as_bytes());
-        buffer.push(0);
-        buffer.extend_from_slice(&(source.source.len() as u64).to_le_bytes());
-        buffer.extend_from_slice(source.source.as_bytes());
-        buffer.push(0);
-    }
-    hash_bytes(&buffer)
+    let shared: Vec<vellum_script::ScriptSource> = sources
+        .iter()
+        .map(|source| vellum_script::ScriptSource {
+            path: source.path.clone(),
+            source: source.source.clone(),
+        })
+        .collect();
+    aeon_core::hash::StateHash::from_u64(vellum_script::content_hash(&shared))
 }
 
 /// Loads and validates a content set from source files.
@@ -221,12 +189,11 @@ pub struct ScriptHost {
 }
 
 impl ScriptHost {
-    /// Builds the runtime host.
+    /// Builds the runtime host on the fleet's quiet sandbox.
     pub fn new() -> Self {
-        let mut engine = sandboxed_engine();
-        engine.on_print(|_| {});
-        engine.on_debug(|_, _, _| {});
-        Self { engine }
+        Self {
+            engine: vellum_script::quiet_sandbox(),
+        }
     }
 
     /// Calls a named effect function with a read-only context, returning
@@ -250,17 +217,15 @@ impl ScriptHost {
             .ok_or_else(|| ScriptError::UnknownFile {
                 path: fn_ref.path.clone(),
             })?;
-        let mut scope = Scope::new();
-        // eval_ast(false): the file's top level ran once at load time;
-        // runtime calls invoke retained functions only.
-        let options = rhai::CallFnOptions::new().eval_ast(false);
-        let result: Dynamic = self
-            .engine
-            .call_fn_with_options(options, &mut scope, ast, &fn_ref.name, (context,))
-            .map_err(|err| ScriptError::Runtime {
-                path: fn_ref.path.clone(),
-                message: err.to_string(),
-            })?;
+        // The shared seam calls a retained function without re-running the
+        // file's top level, which ran once at load time.
+        let result: Dynamic =
+            vellum_script::call_fn(&self.engine, ast, &fn_ref.path, &fn_ref.name, context)
+                .map_err(|err| match err {
+                    vellum_script::CallError::Runtime { path, message } => {
+                        ScriptError::Runtime { path, message }
+                    }
+                })?;
         parse_effects(result).map_err(|source| ScriptError::BadEffects {
             path: fn_ref.path.clone(),
             source,

--- a/pasm/spec/architecture/implementation-decisions.yaml
+++ b/pasm/spec/architecture/implementation-decisions.yaml
@@ -1640,3 +1640,30 @@ entities:
         - deterministic-campaign-simulation
         - hand-rolled-deterministic-rng
         - rng-stream-labels-are-identities-not-names
+
+  - decision: script-host-is-the-fleets
+    core:
+      status: accepted
+      confidence: confirmed
+      title: The Sandbox Is Extracted; The Vocabulary Stays
+      summary: >-
+        The Rhai sandbox profile, the framed content hash, and the
+        context-in call seam move to vellum-script, extracted from this
+        game as the fleet's deterministic script host. What stays here is
+        the vocabulary: which builder functions the loading engine
+        registers, the shape of the context a call receives, and how a
+        returned value becomes typed effects — one game's content model,
+        not a general mechanism. A pure extraction, proven rather than
+        asserted: the content hash and every acceptance replay hash are
+        byte-identical across the change.
+      rationale:
+        - >-
+          The sandbox's value is in what it *refuses*, and every refusal has
+          a reason that is easy to lose when the next game writes its own:
+          building deny-by-default from a raw engine rather than stripping a
+          full one, absent wall clock, dummy module resolver, disabled eval,
+          hard limits, integer-only arithmetic. Those reasons are now
+          written once, with tests that fail if a capability creeps back in.
+      references:
+        - deterministic-campaign-simulation
+        - fleet-foundation-adoption

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   # pinned to a rev: the scanner's findings are a gate, so which version
   # produced them matters. Bumping the rev is part of a vellum bump PR — see
   # vellum's docs/handbook/bump-workflow.md.
-  "pasm @ git+https://github.com/jkeywo/vellum@41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#subdirectory=pasm",
+  "pasm @ git+https://github.com/jkeywo/vellum@61cf506e096854a3e05e1a19369deb0901d298d5#subdirectory=pasm",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   # pinned to a rev: the scanner's findings are a gate, so which version
   # produced them matters. Bumping the rev is part of a vellum bump PR — see
   # vellum's docs/handbook/bump-workflow.md.
-  "pasm @ git+https://github.com/jkeywo/vellum@efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#subdirectory=pasm",
+  "pasm @ git+https://github.com/jkeywo/vellum@41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#subdirectory=pasm",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -11,12 +11,12 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pasm", git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }]
+requires-dist = [{ name = "pasm", git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=61cf506e096854a3e05e1a19369deb0901d298d5" }]
 
 [[package]]
 name = "pasm"
 version = "0.1.0"
-source = { git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
+source = { git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=61cf506e096854a3e05e1a19369deb0901d298d5#61cf506e096854a3e05e1a19369deb0901d298d5" }
 dependencies = [
     { name = "pyyaml" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,12 +11,12 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pasm", git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }]
+requires-dist = [{ name = "pasm", git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }]
 
 [[package]]
 name = "pasm"
 version = "0.1.0"
-source = { git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=efdb2d034e07baadd93e3cbf257ba8b3a3a571a9#efdb2d034e07baadd93e3cbf257ba8b3a3a571a9" }
+source = { git = "https://github.com/jkeywo/vellum?subdirectory=pasm&rev=41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471#41d2e6274a7d0d0ddc1c0c0aca3db3cbd2760471" }
 dependencies = [
     { name = "pyyaml" },
 ]


### PR DESCRIPTION
Consumer half of vellum#14's `vellum-script` — and a **pure extraction, proven rather than asserted**.

The sandbox profile, the framed content hash, and the context-in call seam move to the shared crate. What stays here is the vocabulary: the `define_*` builders the loading engine registers, the context schema a call receives, and how a returned value becomes typed effects — this game's content model, not a general mechanism.

**Verification that it moved nothing:**
- `content-hash: c307fc6373275844` — byte-identical to before the change.
- The full 3600-day acceptance round-trip reproduces every hash exactly (`mid a18fbd163cf9c56a`, `final/replay 3557448933dde818`): `ACCEPTANCE OK`.
- 295/295 tests, clippy `-D warnings`, fmt, spec validate clean.

`StateHash::from_u64` is added so the shared digest can be wrapped in this game's hash type without re-deriving it. Decision recorded as `script-host-is-the-fleets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)